### PR TITLE
Fixes open cilk compile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ hello_mpi:
 	$(MPICC) $(CFLAGS) -o hello_mpi hello_mpi.c
 
 hello_cilk:
-	$(CILKCC) $(CFLAGS) -o hello_cilk hello_cilk.c -fcilkplus
+	$(CILKCC) $(CFLAGS) -o hello_cilk hello_cilk.c -fopencilk
 hello_openblas:
 	$(CC) $(CFLAGS) -o hello_openblas hello_openblas.c -lopenblas -lpthread
 


### PR DESCRIPTION
fixes #4 by changing `-fcilkplus` to `-fopencilk` when linking the `opencilk` library in the [Makefile](https://github.com/AUTh-csal/pds-codebase/blob/ecf00bfa5105ba05f83aaae32c365056a5cf6203/Makefile#L18).